### PR TITLE
install composer 1.x instead of 2

### DIFF
--- a/install-composer.sh
+++ b/install-composer.sh
@@ -11,7 +11,7 @@ then
     exit 1
 fi
 
-php composer-setup.php --quiet
+php composer-setup.php --quiet --version=1.10.16
 RESULT=$?
 rm composer-setup.php
 exit $RESULT


### PR DESCRIPTION
it seems that the latest composer 2 is not compatible with some home's deps

https://app.wercker.com/tamtam-pro/home/runs/build/5f96e57d237ec900081e329c?step=5f96e67392ccbf00082453c0

I tried to replace composer/package-versions with composer/package-versions-deprecated. But it still having issues (with composer 2):

https://app.wercker.com/tamtam-pro/home/runs/build/5f97e719237ec900081e9f5b?step=5f97e751b61ea50008663a63